### PR TITLE
Change the url base of ECTRON_MIRROR

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports = function download (opts, cb) {
   var version = opts.version
   if (!version) return cb(new Error('must specify version'))
   var filename = 'electron-v' + version + '-' + platform + '-' + arch + '.zip'
-  var url = process.env.ELECTRON_MIRROR || 'https://github.com/atom/electron/releases/download/v' + version
-  url += '/electron-v' + version + '-' + platform + '-' + arch + '.zip'
+  var url = process.env.ELECTRON_MIRROR || 'https://github.com/atom/electron/releases/download/v'
+  url += version + '/electron-v' + version + '-' + platform + '-' + arch + '.zip'
   var homeDir = homePath()
   var cache = path.join(homeDir, './.electron')
 


### PR DESCRIPTION
The directory structure of http://npm.taobao.org/mirrors/electron/ has been changed.

It's clear now.